### PR TITLE
Fix: Ensure sqlglot generates postgres-specific SQL dialect

### DIFF
--- a/tools/pg_batch_node.py
+++ b/tools/pg_batch_node.py
@@ -53,7 +53,7 @@ class PGBatchNode(Tool):
             else:  # 保留 $argXYZ
                 namedParam = f"%({p.name})s "
             p.replace(namedParam)
-        return typeOf(ast), ast.sql()
+        return typeOf(ast), ast.sql(dialect="postgres")
 
     def _check_query(self, query):
         if query:

--- a/tools/pg_node.py
+++ b/tools/pg_node.py
@@ -68,7 +68,7 @@ class PGNode(Tool):
             else:
                 namedParam = f"%({p.name})s "
             p.replace(namedParam)
-        return typeOf(ast), ast.sql()  # Ex.
+        return typeOf(ast), ast.sql(dialect="postgres")  # Ex.
 
     def _invoke(
         self, parameters: Dict[str, Any]


### PR DESCRIPTION
# What problem does this PR solve?
This PR addresses an issue where sqlglot alters PostgreSQL-specific syntax during the SQL parsing and regeneration process. Specifically, it was observed that CURRENT_TIMESTAMP was being incorrectly converted to CURRENT_TIMESTAMP().

# Before (Current Behavior):
A PostgreSQL query like this:

```INSERT INTO ... VALUES (..., CURRENT_TIMESTAMP, ...) ON CONFLICT ... DO UPDATE SET updated_at = CURRENT_TIMESTAMP;```
was being transformed into:


```INSERT INTO ... VALUES (..., CURRENT_TIMESTAMP(), ...) ON CONFLICT ... DO UPDATE SET updated_at = CURRENT_TIMESTAMP()```